### PR TITLE
fix: loop direction on ModifyEmoteSet

### DIFF
--- a/src/Fumo.Shared/ThirdParty/Emotes/SevenTV/SevenTVService.cs
+++ b/src/Fumo.Shared/ThirdParty/Emotes/SevenTV/SevenTVService.cs
@@ -198,7 +198,7 @@ public class SevenTVService : AbstractGraphQLClient, ISevenTVService
 
         var response = await Send<SevenTVModifyEmoteSetRoot>(request, ct);
 
-        return response.EmoteSet.Emotes.Where(x => x.ID == emoteID).FirstOrDefault()?.Name ?? default;
+        return response.EmoteSet.Emotes.LastOrDefault(x => x.ID == emoteID)?.Name ?? default;
     }
 
     public async ValueTask<List<SevenTVEnabledEmote>> GetEnabledEmotes(string emoteSet, CancellationToken ct = default)


### PR DESCRIPTION
7TV made it so that you can have the same emote with multiple different aliases in a set. Since the emote gets added to the tail of the set, for a correct mutation response, and efficiency, the loop should be done in reverse.
```
[2024-11-24 09:01:29] #brian6932 brian6932: mb add 01H6999NGR000909D82EXR7X9D
[2024-11-24 09:01:32] #brian6932 melonbot__: Added emote test
[2024-11-24 09:01:37] #brian6932 brian6932: mb add 01H6999NGR000909D82EXR7X9D -a test123
[2024-11-24 09:01:39] #brian6932 melonbot__: Added emote test
[2024-11-24 09:01:45] #brian6932 brian6932: mb remove test
[2024-11-24 09:01:47] #brian6932 melonbot__: All specified emotes were successfully removed
```